### PR TITLE
nginx-syntax: support highlighting for variables with curly braces

### DIFF
--- a/nginx.xml
+++ b/nginx.xml
@@ -1726,7 +1726,7 @@
 			<RegExpr attribute="Variable" context="#stay" String="((2[0-5]|1[0-9]|[0-9])?[0-9]\.){3}(2[0-5]|1[0-9]|[0-9])?[0-9]" />
 			<DetectChar attribute="String" context="doublequotestring" char="&quot;" />
 			<DetectChar attribute="String" context="singlequotestring" char="'" />
-			<RegExpr attribute="Variable" context="#stay" String="\$+[a-zA-Z0-9_\x7f-\xff]+" />
+			<RegExpr attribute="Variable" context="#stay" String="\$+\{?[a-zA-Z0-9_\x7f-\xff]+\}?" />
 			<RegExpr attribute="Size" context="#stay" String="\d+[smhdk](?=\W|$)" />
 			<Float attribute="Float" context="#stay" />
 			<Int attribute="Decimal" context="#stay" />
@@ -1734,12 +1734,12 @@
 		</context>
 
 		<context name="doublequotestring" attribute="String" lineEndContext="#stay">
-			<RegExpr attribute="Variable" context="#stay" String="\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*" />
+			<RegExpr attribute="Variable" context="#stay" String="\$+\{?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\}?" />
 			<Detect2Chars attribute="Backslash Code" context="#stay" char="\" char1="&quot;" />
 			<DetectChar attribute="String" context="#pop" char="&quot;" />
 		</context>
 		<context name="singlequotestring" attribute="String" lineEndContext="#stay">
-			<RegExpr attribute="Variable" context="#stay" String="\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*" />
+			<RegExpr attribute="Variable" context="#stay" String="\$+\{?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\}?" />
 			<Detect2Chars attribute="Backslash Code" context="#stay" char="\" char1="'" />
 			<Detect2Chars attribute="Backslash Code" context="#stay" char="\" char1="\" />
 			<DetectChar attribute="String" context="#pop" char="'" />
@@ -1754,7 +1754,7 @@
 		</context>
 
 		<context name="rewrite_replacement" attribute="Normal Text" lineEndContext="#stay">
-			<RegExpr attribute="Variable" context="#stay" String="\$+[a-zA-Z0-9_\x7f-\xff]+" />
+			<RegExpr attribute="Variable" context="#stay" String="\$+\{?[a-zA-Z0-9_\x7f-\xff]+\}?" />
 			<RegExpr attribute="Symbol" context="rewrite_flag" String="\s" />
 			<DetectChar context="#pop" attribute="Symbol" char=";" lookAhead="true" />
 		</context>


### PR DESCRIPTION
nginx supports specifying variables with curly braces, similar to bash (e.g.: ${var})
This change will make kate highlight them as well.